### PR TITLE
Fix SaveChanges UoW check

### DIFF
--- a/src/Rene.Utils.Db/Builder/GenericCommandHandler.cs
+++ b/src/Rene.Utils.Db/Builder/GenericCommandHandler.cs
@@ -170,7 +170,12 @@
 
         private async Task<int> SaveChanges(CancellationToken cancellationToken)
         {
-            if (_uow == null || _uow.GetType().IsAssignableFrom(typeof(FakeUnitOfWork<>))) return await _dbContext.SaveChangesAsync(cancellationToken);
+            if (_uow == null ||
+                (_uow.GetType().IsGenericType &&
+                 _uow.GetType().GetGenericTypeDefinition() == typeof(FakeUnitOfWork<>)))
+            {
+                return await _dbContext.SaveChangesAsync(cancellationToken);
+            }
 
             return await _uow.SaveChangesAsync(cancellationToken);
         }

--- a/src/Rene.Utils.Db/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Rene.Utils.Db/DependencyInjection/ServiceCollectionExtensions.cs
@@ -148,8 +148,6 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             return builder.AddMediatRGenericHandlers(options);
-
-            return builder;
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix check for FakeUnitOfWork in `GenericCommandHandler` to properly detect generic type
- remove unreachable `return` in `ServiceCollectionExtensions`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863bf44c5a88328bb36fb9a52b235e6