### PR TITLE
Bump version to 1.2.0 and add include specification method

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="dependencies.props" />
   <PropertyGroup>
     <VersionPrefix>1</VersionPrefix>
-    <Version>$(VersionPrefix).1.0.0</Version>
+    <Version>$(VersionPrefix).2.0.0</Version>
 
     <FileVersion>$(Version)</FileVersion>
     <Authors>René Pacios</Authors>

--- a/src/Rene.Utils.Db/CompositeSpecifications/SpecificationCombinator.cs
+++ b/src/Rene.Utils.Db/CompositeSpecifications/SpecificationCombinator.cs
@@ -83,6 +83,33 @@ namespace Rene.Utils.Db.CompositeSpecifications
             var sortSequence = sortQueryString.ToSortSequenceExpression<T>();
             return left.OrderBy(sortSequence);
         }
+
+
+        /// <summary>
+        /// Adds an include expression to the specification for eager loading related entities.
+        /// </summary>
+        /// <typeparam name="T">The entity type.</typeparam>
+        /// <param name="specification">The specification to which the include expression will be added.</param>
+        /// <param name="includeExpression">The expression specifying the related entity to include.</param>
+        /// <returns>
+        /// The composite specification with the added include expression.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the specification does not support includes.
+        /// </exception>
+        public static IDbUtilsCompositeSpecification<T> AddIncludeSpecification<T>(this IDbUtilsSpecification<T> specification,
+            Expression<Func<T, object>> includeExpression)
+        {
+            if (specification is IDbUtilsCompositeSpecification<T> compositeSpecification)
+            {
+                compositeSpecification.Includes.Add(includeExpression);
+                return compositeSpecification;
+            }
+            else
+            {
+                throw new InvalidOperationException("The specification does not support includes.");
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Updated the `Version` property in `Directory.Build.props` from `1.1.0` to `1.2.0`.

Introduced a new method `AddIncludeSpecification<T>` in the `SpecificationCombinator.cs` file to facilitate adding include expressions for eager loading related entities, complete with XML documentation for clarity.