### PR TITLE
Fix include helper to create specification

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="dependencies.props" />
   <PropertyGroup>
     <VersionPrefix>1</VersionPrefix>
-    <Version>$(VersionPrefix).2.0.0</Version>
+    <Version>$(VersionPrefix).2.1.0</Version>
 
     <FileVersion>$(Version)</FileVersion>
     <Authors>René Pacios</Authors>

--- a/src/Rene.Utils.Db/CompositeSpecifications/SpecificationCombinator.cs
+++ b/src/Rene.Utils.Db/CompositeSpecifications/SpecificationCombinator.cs
@@ -102,6 +102,10 @@ namespace Rene.Utils.Db.CompositeSpecifications
         {
             if (specification is IDbUtilsCompositeSpecification<T> compositeSpecification)
             {
+                if (compositeSpecification?.Includes == null)
+                {
+                    ((CompositeSpecification<T>)compositeSpecification).Includes ??= new List<Expression<Func<T, object>>>();
+                }
                 compositeSpecification.Includes.Add(includeExpression);
                 return compositeSpecification;
             }


### PR DESCRIPTION
Update version to 2.1.0 and improve specification handling

Updated the version number in `Directory.Build.props` from `2.0.0` to `2.1.0`. Added a null check in the `AddIncludeSpecification` method to ensure the `Includes` property is initialized before adding new expressions.